### PR TITLE
style: change name of variables for the sake of clarity

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -139,29 +139,29 @@ describe('Voices', () => {
   })
 
   test('it should return voice data by given gender', () => {
-    const portuguese = voices.byGender('female')
-    expect(portuguese.val).toBeArray()
-    expect(portuguese.val[0]).toBeObject()
-    expect(portuguese.val[0]).toContainAllKeys(voiceObjectKeys)
-    expect(portuguese.id).toBeString()
+    const femaleVoice = voices.byGender('female')
+    expect(femaleVoice.val).toBeArray()
+    expect(femaleVoice.val[0]).toBeObject()
+    expect(femaleVoice.val[0]).toContainAllKeys(voiceObjectKeys)
+    expect(femaleVoice.id).toBeString()
   })
 
   test('it should return voice data by given id', () => {
-    const portuguese = voices.byId('Vitoria')
-    expect(portuguese.val).toBeArray()
-    expect(portuguese.val[0]).toBeObject()
-    expect(portuguese.val[0]).toContainAllKeys(voiceObjectKeys)
-    expect(portuguese.id).toBeString()
+    const voiceById = voices.byId('Vitoria')
+    expect(voiceById.val).toBeArray()
+    expect(voiceById.val[0]).toBeObject()
+    expect(voiceById.val[0]).toContainAllKeys(voiceObjectKeys)
+    expect(voiceById.id).toBeString()
   })
 
   test('it should return ENGLISH voice data', () => {
     const spy = jest.spyOn(voices, 'byLang')
-    const portuguese = voices.english()
+    const english = voices.english()
 
-    expect(portuguese.val).toBeArray()
-    expect(portuguese.val[0]).toBeObject()
-    expect(portuguese.val[0]).toContainAllKeys(voiceObjectKeys)
-    expect(portuguese.id).toBeString()
+    expect(english.val).toBeArray()
+    expect(english.val[0]).toBeObject()
+    expect(english.val[0]).toContainAllKeys(voiceObjectKeys)
+    expect(english.id).toBeString()
 
     expect(spy).toHaveBeenCalledWith('English')
 


### PR DESCRIPTION
Some variables in the tests had misleading names most likely due to copy and pasting.

## Proposed changes

While working on https://github.com/chgasparoto/aws-polly-voices/issues/30 I noticed that a few tests used the same variable name `portuguese` for tests that were nor related to portuguese language. I've decided to push this to a different PR to keep it lean and organized. 

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/chgasparoto/aws-polly-voices/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)